### PR TITLE
[needs-docs] Changed Label in file - qgslayoutmapgridwidgetbase.ui

### DIFF
--- a/src/ui/layout/qgslayoutmapgridwidgetbase.ui
+++ b/src/ui/layout/qgslayoutmapgridwidgetbase.ui
@@ -308,7 +308,7 @@
           <item row="1" column="0">
            <widget class="QLabel" name="mFrameWidthLabel">
             <property name="text">
-             <string>Frame size</string>
+             <string>Frame width</string>
             </property>
             <property name="wordWrap">
              <bool>false</bool>


### PR DESCRIPTION
## Description
- The "Frame Size" label has been changed to "Frame width". [needs-docs]

The names of the variables in the program code correspond to the new label. Changes in the program code are not required.

![default](https://user-images.githubusercontent.com/17308458/45029520-9c8b1400-b051-11e8-89f9-6a84f4a9c1dd.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
